### PR TITLE
Fix incorrect naming for MacRoman encoding

### DIFF
--- a/library/ZendPdf/BinaryParser/AbstractBinaryParser.php
+++ b/library/ZendPdf/BinaryParser/AbstractBinaryParser.php
@@ -428,7 +428,7 @@ abstract class AbstractBinaryParser
         if ($characterSet == 'MacRoman') {
             return $bytes;
         }
-        return iconv('MacRoman', $characterSet, $bytes);
+        return iconv('macintosh', $characterSet, $bytes);
     }
 
     /**


### PR DESCRIPTION
I was getting the following error on our hosting's server which uses Linux 3.9.3-x86_64-linode33 and PHP 5.3.10-1ubuntu3.6. The `iconv` library that was used is glibc v2.15.

```
log.ERROR: exception 'ErrorException' with message 'iconv(): Wrong charset, conversion from `MacRoman' to `UTF-16BE' is not allowed' in 
/var/www/h10462/sites/www/htdocs/vendor/zendframework/zendpdf/library/ZendPdf/BinaryParser/AbstractBinaryParser.php:431
```

MacRoman encoding uses the word "macintosh" as its primary identifier as defined by the IANA. See http://en.wikipedia.org/wiki/Mac_OS_Roman for more info.

This fixes problems when using `iconv` to convert MacRoman encoding to other encodings on unix OS (and perhaps other OS types).
