### PR TITLE
Renamed class and filename fixing spelling error

### DIFF
--- a/library/ZendPdf/Util/RecursivelyIterableObjectsContainer.php
+++ b/library/ZendPdf/Util/RecursivelyIterableObjectsContainer.php
@@ -16,7 +16,7 @@ namespace ZendPdf\Util;
  * @package    Zend_PDF
  * @subpackage Zend_PDF_Util
  */
-class RecursivelyIterableObjectsContainer extends RecursivelyIterableObjectsContainer implements \RecursiveIterator, \Countable
+class RecursivelyIterableObjectsContainer implements \RecursiveIterator, \Countable
 {
     protected $_objects = array();
 

--- a/library/ZendPdf/Util/RecursivelyIteratableObjectsContainer.php
+++ b/library/ZendPdf/Util/RecursivelyIteratableObjectsContainer.php
@@ -17,34 +17,6 @@ namespace ZendPdf\Util;
  * @subpackage Zend_PDF_Util
  * @deprecated Use RecursivelyIterableObjectsContainer instead
  */
-class RecursivelyIteratableObjectsContainer implements \RecursiveIterator, \Countable
+class RecursivelyIteratableObjectsContainer extends RecursivelyIterableObjectsContainer implements \RecursiveIterator, \Countable
 {
-    protected $_objects = array();
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function __construct(array $objects) { $this->_objects = $objects; }
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function current()      { return current($this->_objects);            }
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function key()          { return key($this->_objects);                }
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function next()         { return next($this->_objects);               }
-    
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function rewind()       { return reset($this->_objects);              }
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function valid()        { return current($this->_objects) !== false;  }
-    
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function getChildren()  { return current($this->_objects);            }
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function hasChildren()  { return count($this->_objects) > 0;          }
-
-    /** @deprecated use RecursivelyIterableObjectsContainer instead */
-    public function count() { return count($this->_objects); }
 }


### PR DESCRIPTION
Fixing this issue:
https://github.com/zendframework/ZendPdf/issues/10
