### PR TITLE
remove space at end of line for pdf/a-1b standart

### DIFF
--- a/library/ZendPdf/InternalType/IndirectObject.php
+++ b/library/ZendPdf/InternalType/IndirectObject.php
@@ -161,7 +161,7 @@ class IndirectObject extends AbstractTypeObject
     {
         $shift = $factory->getEnumerationShift($this->_factory);
 
-        return  $this->_objNum + $shift . " " . $this->_genNum . " obj \n"
+        return  $this->_objNum + $shift . " " . $this->_genNum . " obj\n"
              .  $this->_value->toString($factory) . "\n"
              . "endobj\n";
     }

--- a/library/ZendPdf/InternalType/StreamObject.php
+++ b/library/ZendPdf/InternalType/StreamObject.php
@@ -397,7 +397,7 @@ class StreamObject extends IndirectObject
         // Update stream length
         $this->dictionary->Length->value = $this->_value->length();
 
-        return  $this->_objNum + $shift . " " . $this->_genNum . " obj \n"
+        return  $this->_objNum + $shift . " " . $this->_genNum . " obj\n"
              .  $this->dictionary->toString($factory) . "\n"
              .  $this->_value->toString($factory) . "\n"
              . "endobj\n";


### PR DESCRIPTION
remove space at end of line for pdf/a-1b standart
Getting rid of following error:

The separator after an 'obj' must be an EOL
